### PR TITLE
Ver 0.70

### DIFF
--- a/Software/AVR128DA28/SignalSlinger/defs.h
+++ b/Software/AVR128DA28/SignalSlinger/defs.h
@@ -33,7 +33,7 @@
 
 /******************************************************
  * Set the text that gets displayed to the user */
-#define SW_REVISION "0.60"
+#define SW_REVISION "0.70"
 
 //#define TRANQUILIZE_WATCHDOG
 
@@ -189,6 +189,9 @@ typedef unsigned char uint8_t;
 #define EXT_BAT_CHARGE_SUPPORT_THRESH_LOW (10.)
 #define EXT_BAT_PRESENT_VOLTAGE (6.0)
 
+#define MINIMUM_VALID_TEMP (-20.)
+#define MAXIMUM_VALID_TEMP (125.)
+
 
 
 typedef uint16_t BatteryLevel;  /* in milliVolts */
@@ -277,6 +280,7 @@ typedef uint16_t BatteryLevel;  /* in milliVolts */
 #define TEXT_RTC_NOT_RESPONDING_TXT (char*)"* Error: No response from clock hardware\n"
 #define TEXT_TX_NOT_RESPONDING_TXT (char*)"* Error: No response from transmit hardware\n"
 #define TEXT_WIFI_NOT_DETECTED_TXT (char*)"* Warning: WiFi hardware not detected\n"
+#define TEXT_EXCESSIVE_TEMPERATURE (char*)"* Error: High Temperature Shutdown!\n"
 #define TEXT_RESET_OCCURRED_TXT (char*)"* Warning: CPU Reset! Need to set clock\n"
 #define TEXT_DEVICE_DISABLED_TXT (char*)"\n* Device Disabled! Enable with 8 button presses\n"
 #define TEXT_NOT_SLEEPING_TXT (char*)"\n* Awake\n"

--- a/Software/AVR128DA28/SignalSlinger/include/adc.h
+++ b/Software/AVR128DA28/SignalSlinger/include/adc.h
@@ -50,6 +50,8 @@ void ADC0_startConversion(void);
 bool ADC0_conversionDone(void);
 int ADC0_read(void);
 float temperatureC(void);
+float temperatureCfromADC(uint16_t adc_reading);
+bool isValidTemp(float temperatureC);
 float readVoltage(ADC_Active_Channel_t chan);
 void ADC0_SYSTEM_init(bool freerun);
 void ADC0_SYSTEM_shutdown(void);

--- a/Software/AVR128DA28/SignalSlinger/include/transmitter.h
+++ b/Software/AVR128DA28/SignalSlinger/include/transmitter.h
@@ -89,7 +89,11 @@ EC powerToTransmitter(bool on);
 
 /** 
  */
-//void txKeyDown(bool key);
+void setDisableTransmissions(bool disabled);
+
+/** 
+ */
+bool getDisableTransmissions(void);
 
 /**
  */

--- a/Software/AVR128DA28/SignalSlinger/include/util.h
+++ b/Software/AVR128DA28/SignalSlinger/include/util.h
@@ -51,5 +51,9 @@ bool frequencyVal(char* str, Frequency_Hz* result);
 bool fox2Text(char* str, Fox_t fox);
 bool event2Text(char* str, Event_t evt);
 bool function2Text(char* str, Function_t fun);
+bool float_to_parts_signed(float value,
+                           int16_t  *integerPart,   /* signed  */
+                           uint16_t *fractionPart);         /* unsigned */
+
 
 #endif  /* UTIL_H_ */


### PR DESCRIPTION
o Fixes the bug that broke cloning in 0.50 and 0.60 o More fully implements disabling power from an external battery, but the feature is not fully verified o Makes events timed to start in the future more robust, by always configuring them to run unless the current clock time is reset o Displays processor temperature (current, maximum, and minimum since power up) over the serial port o Prints an error message if the processor temperature exceeds 60C. Message is cleared when the temperature falls below 55C.