### PR TITLE
Ver 0.72

### DIFF
--- a/Software/AVR128DA28/SignalSlinger/SignalSlinger.cppproj
+++ b/Software/AVR128DA28/SignalSlinger/SignalSlinger.cppproj
@@ -136,71 +136,71 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <ToolchainSettings>
       <AvrGccCpp>
-  <avrgcc.common.Device>-mmcu=avr128da28 -B "%24(PackRepoDir)\atmel\AVR-Dx_DFP\1.9.103\gcc\dev\avr128da28"</avrgcc.common.Device>
-  <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
-  <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
-  <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
-  <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
-  <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
-  <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
-  <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
-  <avrgcc.compiler.symbols.DefSymbols>
-    <ListValues>
-      <Value>DEBUG</Value>
-    </ListValues>
-  </avrgcc.compiler.symbols.DefSymbols>
-  <avrgcc.compiler.directories.IncludePaths>
-    <ListValues>
-      <Value>../Config</Value>
-      <Value>../include</Value>
-      <Value>../utils</Value>
-      <Value>../utils/assembler</Value>
-      <Value>../</Value>
-      <Value>%24(PackRepoDir)\atmel\AVR-Dx_DFP\1.9.103\include\</Value>
-    </ListValues>
-  </avrgcc.compiler.directories.IncludePaths>
-  <avrgcc.compiler.optimization.level>Optimize debugging experience (-Og)</avrgcc.compiler.optimization.level>
-  <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
-  <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
-  <avrgcc.compiler.optimization.DebugLevel>Default (-g2)</avrgcc.compiler.optimization.DebugLevel>
-  <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
-  <avrgcc.compiler.miscellaneous.OtherFlags>-std=gnu99 -fno-threadsafe-statics</avrgcc.compiler.miscellaneous.OtherFlags>
-  <avrgcccpp.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcccpp.compiler.general.ChangeDefaultCharTypeUnsigned>
-  <avrgcccpp.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcccpp.compiler.general.ChangeDefaultBitFieldUnsigned>
-  <avrgcccpp.compiler.symbols.DefSymbols>
-    <ListValues>
-      <Value>DEBUG</Value>
-    </ListValues>
-  </avrgcccpp.compiler.symbols.DefSymbols>
-  <avrgcccpp.compiler.directories.IncludePaths>
-    <ListValues>
-      <Value>../Config</Value>
-      <Value>../include</Value>
-      <Value>../utils</Value>
-      <Value>../utils/assembler</Value>
-      <Value>../</Value>
-      <Value>%24(PackRepoDir)\atmel\AVR-Dx_DFP\1.9.103\include\</Value>
-    </ListValues>
-  </avrgcccpp.compiler.directories.IncludePaths>
-  <avrgcccpp.compiler.optimization.level>Optimize debugging experience (-Og)</avrgcccpp.compiler.optimization.level>
-  <avrgcccpp.compiler.optimization.PackStructureMembers>True</avrgcccpp.compiler.optimization.PackStructureMembers>
-  <avrgcccpp.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcccpp.compiler.optimization.AllocateBytesNeededForEnum>
-  <avrgcccpp.compiler.optimization.DebugLevel>Default (-g2)</avrgcccpp.compiler.optimization.DebugLevel>
-  <avrgcccpp.compiler.warnings.AllWarnings>True</avrgcccpp.compiler.warnings.AllWarnings>
-  <avrgcccpp.compiler.miscellaneous.OtherFlags>-fno-threadsafe-statics</avrgcccpp.compiler.miscellaneous.OtherFlags>
-  <avrgcccpp.linker.libraries.Libraries>
-    <ListValues>
-      <Value>libm</Value>
-    </ListValues>
-  </avrgcccpp.linker.libraries.Libraries>
-  <avrgcccpp.assembler.general.IncludePaths>
-    <ListValues>
-      <Value>../utils</Value>
-      <Value>%24(PackRepoDir)\atmel\AVR-Dx_DFP\1.9.103\include\</Value>
-    </ListValues>
-  </avrgcccpp.assembler.general.IncludePaths>
-  <avrgcccpp.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcccpp.assembler.debugging.DebugLevel>
-</AvrGccCpp>
+        <avrgcc.common.Device>-mmcu=avr128da28 -B "%24(PackRepoDir)\atmel\AVR-Dx_DFP\1.9.103\gcc\dev\avr128da28"</avrgcc.common.Device>
+        <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
+        <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
+        <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
+        <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
+        <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
+        <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
+        <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
+        <avrgcc.compiler.symbols.DefSymbols>
+          <ListValues>
+            <Value>DEBUG</Value>
+          </ListValues>
+        </avrgcc.compiler.symbols.DefSymbols>
+        <avrgcc.compiler.directories.IncludePaths>
+          <ListValues>
+            <Value>../Config</Value>
+            <Value>../include</Value>
+            <Value>../utils</Value>
+            <Value>../utils/assembler</Value>
+            <Value>../</Value>
+            <Value>%24(PackRepoDir)\atmel\AVR-Dx_DFP\1.9.103\include\</Value>
+          </ListValues>
+        </avrgcc.compiler.directories.IncludePaths>
+        <avrgcc.compiler.optimization.level>Optimize debugging experience (-Og)</avrgcc.compiler.optimization.level>
+        <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
+        <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
+        <avrgcc.compiler.optimization.DebugLevel>Default (-g2)</avrgcc.compiler.optimization.DebugLevel>
+        <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
+        <avrgcc.compiler.miscellaneous.OtherFlags>-std=gnu99 -fno-threadsafe-statics</avrgcc.compiler.miscellaneous.OtherFlags>
+        <avrgcccpp.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcccpp.compiler.general.ChangeDefaultCharTypeUnsigned>
+        <avrgcccpp.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcccpp.compiler.general.ChangeDefaultBitFieldUnsigned>
+        <avrgcccpp.compiler.symbols.DefSymbols>
+          <ListValues>
+            <Value>DEBUG</Value>
+          </ListValues>
+        </avrgcccpp.compiler.symbols.DefSymbols>
+        <avrgcccpp.compiler.directories.IncludePaths>
+          <ListValues>
+            <Value>../Config</Value>
+            <Value>../include</Value>
+            <Value>../utils</Value>
+            <Value>../utils/assembler</Value>
+            <Value>../</Value>
+            <Value>%24(PackRepoDir)\atmel\AVR-Dx_DFP\1.9.103\include\</Value>
+          </ListValues>
+        </avrgcccpp.compiler.directories.IncludePaths>
+        <avrgcccpp.compiler.optimization.level>Optimize debugging experience (-Og)</avrgcccpp.compiler.optimization.level>
+        <avrgcccpp.compiler.optimization.PackStructureMembers>True</avrgcccpp.compiler.optimization.PackStructureMembers>
+        <avrgcccpp.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcccpp.compiler.optimization.AllocateBytesNeededForEnum>
+        <avrgcccpp.compiler.optimization.DebugLevel>Default (-g2)</avrgcccpp.compiler.optimization.DebugLevel>
+        <avrgcccpp.compiler.warnings.AllWarnings>True</avrgcccpp.compiler.warnings.AllWarnings>
+        <avrgcccpp.compiler.miscellaneous.OtherFlags>-fno-threadsafe-statics</avrgcccpp.compiler.miscellaneous.OtherFlags>
+        <avrgcccpp.linker.libraries.Libraries>
+          <ListValues>
+            <Value>libm</Value>
+          </ListValues>
+        </avrgcccpp.linker.libraries.Libraries>
+        <avrgcccpp.assembler.general.IncludePaths>
+          <ListValues>
+            <Value>../utils</Value>
+            <Value>%24(PackRepoDir)\atmel\AVR-Dx_DFP\1.9.103\include\</Value>
+          </ListValues>
+        </avrgcccpp.assembler.general.IncludePaths>
+        <avrgcccpp.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcccpp.assembler.debugging.DebugLevel>
+      </AvrGccCpp>
     </ToolchainSettings>
   </PropertyGroup>
   <ItemGroup>

--- a/Software/AVR128DA28/SignalSlinger/defs.h
+++ b/Software/AVR128DA28/SignalSlinger/defs.h
@@ -33,7 +33,7 @@
 
 /******************************************************
  * Set the text that gets displayed to the user */
-#define SW_REVISION "0.70"
+#define SW_REVISION "0.72"
 
 //#define TRANQUILIZE_WATCHDOG
 
@@ -184,10 +184,14 @@ typedef unsigned char uint8_t;
 #define VPA(x)((x * PA_VOLTAGE_MAX_MV) / 1023L)
 
 #define INT_BAT_PRESENT_VOLTAGE (0.5)
-#define INT_BAT_CHARGE_THRESH_LOW (4.0)
+#define INT_BAT_CHARGE_THRESH_LOW_MIN (3.0)
+#define INT_BAT_CHARGE_THRESH_LOW_MAX (4.1)
 #define INT_BAT_CHARGE_THRES_HIGH (4.2)
 #define EXT_BAT_CHARGE_SUPPORT_THRESH_LOW (10.)
 #define EXT_BAT_PRESENT_VOLTAGE (6.0)
+
+#define FAN_TURN_ON_TEMP (45.)
+#define FAN_TURN_OFF_TEMP (40.)
 
 #define MINIMUM_VALID_TEMP (-20.)
 #define MAXIMUM_VALID_TEMP (125.)
@@ -244,7 +248,7 @@ typedef uint16_t BatteryLevel;  /* in milliVolts */
 #define EEPROM_FUNCTION_DEFAULT Function_ARDF_TX
 
 #define EEPROM_CLOCK_CALIBRATION_DEFAULT 32767
-#define EEPROM_BATTERY_THRESHOLD_V (3.800)
+#define EEPROM_INT_BATTERY_LOW_THRESHOLD_V (3.800)
 #define MAX_UNLOCK_CODE_LENGTH 8
 #define EEPROM_DTMF_UNLOCK_CODE_DEFAULT "1357"
 #define MIN_UNLOCK_CODE_LENGTH 4

--- a/Software/AVR128DA28/SignalSlinger/include/binio.h
+++ b/Software/AVR128DA28/SignalSlinger/include/binio.h
@@ -63,7 +63,8 @@ enum hardwareResourceClients {
 	INTERNAL_BATTERY_CHARGING,
 	TRANSMITTER,
 	NUMBER_OF_LS_CONTROLLERS,
-	INITIALIZE_LS
+	INITIALIZE_LS,
+	RE_APPLY_LS_STATE
 };
 
 /**
@@ -89,6 +90,7 @@ void fet_driver(bool state);
 
 /**
  */
+bool setExtBatLoadSwitch(hardwareResourceClients client);
 bool setExtBatLoadSwitch(bool onoff, hardwareResourceClients sender);
 
 /**
@@ -102,6 +104,7 @@ bool setBoostEnable(bool onoff);
 /**
  */
 bool setExtBatLSSetting(bool onoff);
+bool getExtBatLSEnable(void);
 
 class binio
 {

--- a/Software/AVR128DA28/SignalSlinger/include/serialbus.h
+++ b/Software/AVR128DA28/SignalSlinger/include/serialbus.h
@@ -78,7 +78,7 @@ typedef enum
 
 	/*	ARDUCON MESSAGE FAMILY (SERIAL MESSAGING) */
 	SB_MESSAGE_SET_FOX = 'F' * 100 + 'O' * 10 + 'X',			/* Set the fox role to be used to define timing and signals */
-	SB_MESSAGE_VOLTS = 'B' * 100 + 'A' * 10 + 'T',				/* Battery voltage and threshold setting */
+	SB_MESSAGE_BATTERY = 'B' * 100 + 'A' * 10 + 'T',				/* Battery voltage and threshold setting */
 	SB_MESSAGE_SET_STATION_ID = 'I' * 10 + 'D',					/* Sets amateur radio callsign text */
 	SB_MESSAGE_GO = 'G' * 10 + 'O',								/* Start/stop transmissions */
 	SB_MESSAGE_CODE_SETTINGS = 'S' * 100 + 'P' * 10 + 'D',		/* Set Morse code speeds */
@@ -140,7 +140,7 @@ typedef struct
 } SerialbusRxBuffer;
 
 #define WAITING_FOR_UPDATE -1
-#define HELP_TEXT_TXT (char*)"\n* Commands:\n* > ? - Report all settings\n* > CLK [T|S|F|D [\"YYMMDDhhmmss\"]] - Read/set time/start/finish/days\n* > EVT [B|C|F|S] - Set event\n* > FOX [fox]- Set fox role\n* > FRE [frequency] - Set tx frequency\n* > ID [callsign] -  Set callsign\n* > KEY [1|0] - key down/up\n* > MAS [0|1] - Set slave or master\n* > PAT [text] - Set xmit pattern\n* > SPD I|F|P [wpm] - Set ID code speed\n* > GO 0-3 - Start event\n* > BAT [v] - Battery volts\n\0"
+#define HELP_TEXT_TXT (char*)"\n* Commands:\n* > ? - Report all settings\n* > CLK [T|S|F|D [\"YYMMDDhhmmss\"]] - Read/set time/start/finish/days\n* > EVT [B|C|F|S] - Set event\n* > FOX [fox]- Set fox role\n* > FRE [frequency] - Set tx frequency\n* > ID [callsign] -  Set callsign\n* > KEY [1|0] - key down/up\n* > MAS [0|1] - Set Source or Target\n* > PAT [text] - Set xmit pattern\n* > SPD I|F|P [wpm] - Set ID code speed\n* > GO 0-3 - Start event\n* > BAT [T|X] [0-2] - Battery\n\0"
 
 
 /**

--- a/Software/AVR128DA28/SignalSlinger/main.cpp
+++ b/Software/AVR128DA28/SignalSlinger/main.cpp
@@ -126,7 +126,7 @@ volatile time_t g_event_start_epoch = EEPROM_START_TIME_DEFAULT;
 volatile time_t g_event_finish_epoch = EEPROM_FINISH_TIME_DEFAULT;
 volatile bool g_event_enabled = EEPROM_EVENT_ENABLED_DEFAULT;                        /* indicates that the conditions for executing the event are set */
 volatile bool g_event_commenced = false;
-volatile float g_voltage_threshold = EEPROM_BATTERY_THRESHOLD_V;
+volatile float g_internal_voltage_low_threshold = EEPROM_INT_BATTERY_LOW_THRESHOLD_V;
 volatile float g_internal_bat_voltage = 0.;
 volatile float g_internal_bat_detected = false;
 volatile float g_external_voltage = 0.;
@@ -154,6 +154,7 @@ static volatile bool g_check_for_long_wakeup_press = true;
 static volatile bool g_device_wakeup_complete = false;
 static volatile bool g_charge_battery = false;
 extern bool g_enable_boost_regulator;
+static volatile bool g_turn_on_fan = false;
 
 
 #define NUMBER_OF_POLLED_ADC_CHANNELS 3
@@ -522,13 +523,6 @@ ISR(TCB0_INT_vect)
 						{
 							g_switch_closed_time = 0;
 							buttonReleased = true;
-					
-							if(g_send_clone_success_countdown || g_cloningInProgress) 
-							{
-								g_send_clone_success_countdown = 0;
-								g_cloningInProgress = false;
-								g_programming_msg_throttle = 0;
-							}
 						}
 					
 						longPressEnabled = true;
@@ -858,7 +852,10 @@ ISR(TCB0_INT_vect)
 				}
 				else if(g_adcChannelOrder[indexConversionInProcess] == ADCExternalBatteryVoltage)
 				{
-					g_external_voltage = (0.00725 * (float)g_lastConversionResult[indexConversionInProcess]) + 0.05;
+					if(!g_enable_external_battery_control || getExtBatLSEnable()) // Don't try to read a disconnected external battery
+					{
+						g_external_voltage = (0.00725 * (float)g_lastConversionResult[indexConversionInProcess]) + 0.05;
+					}
 				}
 				else if(g_adcChannelOrder[indexConversionInProcess] == ADCTemperature)
 				{
@@ -876,6 +873,21 @@ ISR(TCB0_INT_vect)
 						else
 						{
 							g_temperature_shutdown = g_temperature_shutdown ? !(g_processor_temperature < 80.) : g_processor_temperature > 85.;
+						}
+						
+						if(g_turn_on_fan)
+						{
+							if(g_processor_temperature <= FAN_TURN_OFF_TEMP)
+							{
+								g_turn_on_fan = false;
+							}
+						}
+						else
+						{
+							if(g_processor_temperature > FAN_TURN_ON_TEMP)
+							{
+								g_turn_on_fan = true;
+							}
 						}
 					}
 				}
@@ -961,7 +973,7 @@ int main(void)
 		
 	if(now == time(null))
 	{
-		LEDS.blink(LEDS_GREEN_OFF);
+		LEDS.blink(LEDS_GREEN_OFF); // Signal that the first attempt failed
 		LEDS.blink(LEDS_RED_OFF);
 		while((util_delay_ms(3000)) && (now == time(null)));
 	}
@@ -1004,17 +1016,19 @@ int main(void)
 				
 	buttonReleasedDuringStartup = false;
 	
+	/* Disable automatic ADC readings */
 	TCB0.INTCTRL = 0;   /* Capture or Timeout: disable interrupts */
 	TCB0.CTRLA = 0; /* Disable timer */
+	/* The external battery control load switch is initialized to ON, so we don't need to set it here */
 	g_internal_bat_voltage = readVoltage(ADCInternalBatteryVoltage);
 	g_external_voltage = readVoltage(ADCExternalBatteryVoltage);
 	
 	g_internal_bat_detected = (g_internal_bat_voltage > INT_BAT_PRESENT_VOLTAGE);
 
-	if(g_internal_bat_detected && (g_internal_bat_voltage < INT_BAT_CHARGE_THRESH_LOW) && (g_external_voltage > EXT_BAT_CHARGE_SUPPORT_THRESH_LOW)) // An external voltage is present and an internal battery is present & not fully charged
+	if(g_internal_bat_detected && (g_internal_bat_voltage < g_internal_voltage_low_threshold) && (g_enable_external_battery_control > 0)) // An internal battery is present & not fully charged & charging from an external battery is enabled
 	{
 		g_charge_battery = true;
-		if(g_enable_external_battery_control) setExtBatLoadSwitch(ON, INTERNAL_BATTERY_CHARGING);
+		setExtBatLoadSwitch(ON, INTERNAL_BATTERY_CHARGING);
 	}
 	g_restart_conversions = true;
 	TIMERB_init();
@@ -1060,7 +1074,7 @@ int main(void)
 			// Set internal battery charging
 			if((g_internal_bat_voltage > INT_BAT_PRESENT_VOLTAGE) && (g_external_voltage > EXT_BAT_CHARGE_SUPPORT_THRESH_LOW))
 			{
-				if(g_internal_bat_voltage < INT_BAT_CHARGE_THRESH_LOW) // An adequate external voltage is present and an internal battery is present & not fully charged
+				if(g_internal_bat_voltage < g_internal_voltage_low_threshold) // An adequate external voltage is present and an internal battery is present & not fully charged
 				{
 					g_charge_battery = true;
 				}
@@ -1074,7 +1088,27 @@ int main(void)
 				g_charge_battery = false;
 			}
 			
-			if(g_enable_external_battery_control) setExtBatLoadSwitch(g_charge_battery, INTERNAL_BATTERY_CHARGING);
+			if(g_enable_external_battery_control) 
+			{
+				setExtBatLoadSwitch(g_charge_battery, INTERNAL_BATTERY_CHARGING);
+			}
+			else
+			{
+				if(g_turn_on_fan)
+				{
+					if(!getExtBatLSEnable())
+					{
+						setExtBatLoadSwitch(ON, INITIALIZE_LS);
+					}
+				}
+				else
+				{
+					if(getExtBatLSEnable())
+					{
+						setExtBatLoadSwitch(OFF, INITIALIZE_LS);
+					}
+				}
+			}
 			
 			/********************************
 			 * Handle sleep
@@ -1154,12 +1188,14 @@ int main(void)
 							g_internal_bat_voltage = readVoltage(ADCInternalBatteryVoltage); // Throw out first result following sleep
 							g_external_voltage = readVoltage(ADCExternalBatteryVoltage);
 							system_sleep_config();
+							setExtBatLoadSwitch(RE_APPLY_LS_STATE);
 						
-							if(g_external_voltage > EXT_BAT_CHARGE_SUPPORT_THRESH_LOW)
+							if(g_enable_external_battery_control)
 							{
+
 								if(g_internal_bat_voltage > INT_BAT_PRESENT_VOLTAGE)
 								{
-									if(g_internal_bat_voltage < INT_BAT_CHARGE_THRESH_LOW) // An external voltage is present and an internal battery is present & not fully charged
+									if(g_internal_bat_voltage < g_internal_voltage_low_threshold) // An external voltage is present and an internal battery is present & not fully charged
 									{
 										g_charge_battery = true;
 									}
@@ -1252,7 +1288,15 @@ int main(void)
 			}
 			
 			if(g_handle_counted_presses)
-			{
+			{				
+				if(g_send_clone_success_countdown || g_cloningInProgress)
+				{
+					g_send_clone_success_countdown = 0;
+					g_cloningInProgress = false;
+					g_programming_msg_throttle = 0;
+					g_handle_counted_presses = 0; /* Throw out any keypresses that occurred while cloning or sending cloning success pattern */
+				}
+
 				if(g_isMaster)
 				{
 					if(g_handle_counted_presses == 5)
@@ -1546,7 +1590,7 @@ int main(void)
 			
 			if(g_device_enabled)
 			{
-				internal_bat_error = ((g_internal_bat_voltage > 0.0) && (g_internal_bat_voltage <= g_voltage_threshold));
+				internal_bat_error = (g_internal_bat_detected && (g_internal_bat_voltage <= g_internal_voltage_low_threshold));
 				external_pwr_error = (g_external_voltage <= EXT_BAT_PRESENT_VOLTAGE);
 				
 				if(g_charge_battery)
@@ -2563,7 +2607,7 @@ void __attribute__((optimize("O0"))) handleSerialBusMsgs()
 			}
 			break;
 
-			case SB_MESSAGE_VOLTS:
+			case SB_MESSAGE_BATTERY:
 			{
 				char txt[6];
 
@@ -2571,16 +2615,20 @@ void __attribute__((optimize("O0"))) handleSerialBusMsgs()
 				{
 					float v = atof(sb_buff->fields[SB_FIELD1]);
 
-					if((v >= 0.1) && (v <= 15.))
+					if((v >= INT_BAT_CHARGE_THRESH_LOW_MIN) && (v <= INT_BAT_CHARGE_THRESH_LOW_MAX))
 					{
-						g_voltage_threshold = v;
-						g_ee_mgr.updateEEPROMVar(Voltage_threshold, (void*)&g_voltage_threshold);
+						g_internal_voltage_low_threshold = v;
+						g_ee_mgr.updateEEPROMVar(Voltage_threshold, (void*)&g_internal_voltage_low_threshold);
 					}
 					else
 					{
-						sb_send_string((char*)"\nErr: 0.1 V < thresh < 15.0 V\n");
+						int16_t d1, d2;
+						uint16_t f1, f2;
+						float_to_parts_signed(INT_BAT_CHARGE_THRESH_LOW_MIN, &d1, &f1);
+						float_to_parts_signed(INT_BAT_CHARGE_THRESH_LOW_MAX, &d2, &f2);						
+  						sprintf(g_tempStr, "\nErr: %d.%u V < thresh < %d.%u V\n", d1, f1, d2, f2);
+						sb_send_string(g_tempStr);
 					}
-
 				}
 				else if(sb_buff->fields[SB_FIELD1][0] == 'X')
 				{
@@ -2606,24 +2654,28 @@ void __attribute__((optimize("O0"))) handleSerialBusMsgs()
 						updateStoredValue = true;
 					}
 					
-					if(updateStoredValue) g_ee_mgr.updateEEPROMVar(Enable_External_Battery_Control, (void*)&g_enable_external_battery_control);
+					if(updateStoredValue)
+					{
+						setExtBatLoadSwitch(OFF, INITIALIZE_LS);
+						g_ee_mgr.updateEEPROMVar(Enable_External_Battery_Control, (void*)&g_enable_external_battery_control);
+					}
 				}
-				else if(sb_buff->fields[SB_FIELD1][0] == 'B')
-				{
-					bool v = ((char)sb_buff->fields[SB_FIELD2][0] == '1');
-					g_enable_boost_regulator = v;					
-					g_ee_mgr.updateEEPROMVar(Enable_Boost_Regulator, (void*)&g_enable_boost_regulator);
-				}
+// 				else if(sb_buff->fields[SB_FIELD1][0] == 'B')
+// 				{
+// 					bool v = ((char)sb_buff->fields[SB_FIELD2][0] == '1');
+// 					g_enable_boost_regulator = v;					
+// 					g_ee_mgr.updateEEPROMVar(Enable_Boost_Regulator, (void*)&g_enable_boost_regulator);
+// 				}
 				
-				sprintf(g_tempStr, "\nBoost: %sabled\n", g_enable_boost_regulator ? "En":"Dis");
-				sb_send_string(g_tempStr);
+// 				sprintf(g_tempStr, "\nBoost: %sabled\n", g_enable_boost_regulator ? "En":"Dis");
+// 				sb_send_string(g_tempStr);
 
 				dtostrf(g_internal_bat_voltage, 5, 1, txt);
 				txt[5] = '\0';
-  				sprintf(g_tempStr, "Int. Bat =%s Volts\n", txt);
+  				sprintf(g_tempStr, "\nInt. Bat =%s Volts\n", txt);
  				sb_send_string(g_tempStr);
 
-				dtostrf(g_voltage_threshold, 5, 1, txt);
+				dtostrf(g_internal_voltage_low_threshold, 5, 1, txt);
 				txt[5] = '\0';
  				sprintf(g_tempStr, "thresh   =%s Volts\n", txt);
  				sb_send_string(g_tempStr);
@@ -3626,7 +3678,7 @@ void reportSettings(void)
 		sb_send_string(g_tempStr);
 	}
 
-	// Send the current settings header.
+	// Print the current settings header.
 	sb_send_string(TEXT_CURRENT_SETTINGS_TXT);
 
 	// Report the current system time.
@@ -3808,7 +3860,7 @@ void reportSettings(void)
 		{
 			sprintf(g_tempStr, "\n* WARNING: TRANSMIT DISABLED");
 			sb_send_string(g_tempStr);
-			sprintf(g_tempStr, "\n* Re-enable with BAT X 1\n");
+			sprintf(g_tempStr, "\n* Re-enable with > BAT X 1\n");
 			sb_send_string(g_tempStr);
 		}
 	}

--- a/Software/AVR128DA28/SignalSlinger/src/binio.cpp
+++ b/Software/AVR128DA28/SignalSlinger/src/binio.cpp
@@ -35,9 +35,9 @@ uint8_t portDpinReadings[3];
 uint8_t portDdebounced;
 uint8_t portApinReadings[3];
 uint8_t portAdebounced;
-void setExtBatLSEnable(bool state);
 void v3V3_enable(bool state);
 void boost_enable(bool state);
+void setExtBatLSEnable(bool state);
 
 // default constructor
 binio::binio()
@@ -192,6 +192,12 @@ static volatile bool chargeLScallerStates[NUMBER_OF_LS_CONTROLLERS] = {OFF, OFF}
 /**
  State machine to keep track of multiple controllers of the external battery load switch. This ensures that the switch is ON if any of the controllers has turned it on.
  */
+bool setExtBatLoadSwitch(hardwareResourceClients client)
+{
+	bool currentState = setExtBatLoadSwitch(OFF, RE_APPLY_LS_STATE);
+	return currentState;
+}
+
 bool setExtBatLoadSwitch(bool onoff, hardwareResourceClients sender)
 {
 	
@@ -216,6 +222,7 @@ bool setExtBatLoadSwitch(bool onoff, hardwareResourceClients sender)
 		}
 		break;
 		
+		// case RE_APPLY_LS_STATE:
 		default:
 		break;
 	}
@@ -306,6 +313,11 @@ void setExtBatLSEnable(bool state)
 	{
 		PORTA_set_pin_level(CHARGE_AUX_ENABLE, LOW);
 	}
+}
+	
+bool getExtBatLSEnable(void)
+{
+	return (PORTA_get_pin_level(CHARGE_AUX_ENABLE) != LOW);
 }
 
 void v3V3_enable(bool state)

--- a/Software/AVR128DA28/SignalSlinger/src/driver_init.cpp
+++ b/Software/AVR128DA28/SignalSlinger/src/driver_init.cpp
@@ -70,8 +70,8 @@ void system_charging_config()
 
 //	BINIO_init();
 		/* PORTA *************************************************************************************/
-//  	PORTA_set_pin_dir(CHARGE_AUX_ENABLE, PORT_DIR_OUT);
-//  	PORTA_set_pin_level(CHARGE_AUX_ENABLE, LOW);
+  	PORTA_set_pin_dir(CHARGE_AUX_ENABLE, PORT_DIR_OUT);
+  	PORTA_set_pin_level(CHARGE_AUX_ENABLE, HIGH);
 // 	
 //  	PORTA_set_pin_dir(FET_DRIVER_ENABLE, PORT_DIR_OUT);
 // 	PORTA_set_pin_level(FET_DRIVER_ENABLE, HIGH);

--- a/Software/AVR128DA28/SignalSlinger/src/eeprommanager.cpp
+++ b/Software/AVR128DA28/SignalSlinger/src/eeprommanager.cpp
@@ -150,7 +150,7 @@ extern volatile int16_t g_off_air_seconds;
 extern volatile int16_t g_on_air_seconds;
 extern volatile int16_t g_ID_period_seconds;
 extern volatile int16_t g_intra_cycle_delay_time;
-extern volatile float g_voltage_threshold;
+extern volatile float g_internal_voltage_low_threshold;
 extern uint16_t g_clock_calibration;
 extern volatile uint8_t g_days_to_run;
 extern uint16_t g_i2c_failure_count;
@@ -658,7 +658,7 @@ void EepromManager::saveAllEEPROM(void)
 	updateEEPROMVar(On_Air_Seconds, (void*)&g_on_air_seconds);
 	updateEEPROMVar(ID_Period_Seconds, (void*)&g_ID_period_seconds);
 	updateEEPROMVar(Intra_Cycle_Delay_Seconds, (void*)&g_intra_cycle_delay_time);
-	updateEEPROMVar(Voltage_threshold, (void*)&g_voltage_threshold);
+	updateEEPROMVar(Voltage_threshold, (void*)&g_internal_voltage_low_threshold);
 	updateEEPROMVar(Clock_calibration, (void*)&g_clock_calibration);
 	updateEEPROMVar(Days_to_run, (void*)&g_days_to_run);
 	updateEEPROMVar(I2C_failure_count, (void*)&g_i2c_failure_count);
@@ -751,7 +751,7 @@ bool EepromManager::readNonVols(void)
 		g_ID_period_seconds = CLAMP(0, (int16_t)eeprom_read_word((const uint16_t*)&(EepromManager::ee_vars.ID_period_seconds)), 3600);
 		g_intra_cycle_delay_time = CLAMP(0, (int16_t)eeprom_read_word((const uint16_t*)&(EepromManager::ee_vars.intra_cycle_delay_time)), 3600);
 		
-		g_voltage_threshold = CLAMP(0.1, eeprom_read_float(&(EepromManager::ee_vars.voltage_threshold)), 15.0);
+		g_internal_voltage_low_threshold = CLAMP(3.0, eeprom_read_float(&(EepromManager::ee_vars.voltage_threshold)), 4.1);
 		
 		g_clock_calibration = eeprom_read_word(&(EepromManager::ee_vars.clock_calibration));
 
@@ -891,8 +891,8 @@ bool EepromManager::readNonVols(void)
 
 			avr_eeprom_write_byte(i, '\0');
 
-			g_voltage_threshold = EEPROM_BATTERY_THRESHOLD_V;
-			avr_eeprom_write_float(Voltage_threshold, g_voltage_threshold);
+			g_internal_voltage_low_threshold = EEPROM_INT_BATTERY_LOW_THRESHOLD_V;
+			avr_eeprom_write_float(Voltage_threshold, g_internal_voltage_low_threshold);
 			
 			g_clock_calibration = EEPROM_CLOCK_CALIBRATION_DEFAULT;
 			avr_eeprom_write_word(Clock_calibration, g_clock_calibration);


### PR DESCRIPTION
o After a successful cloning, while the “success” blink pattern is blinking, a keypress will now reset the success state and return a target device to normal operation without causing transmissions to start.

o Charging from the external battery now works when the BAT X 1 or BAT X 2 command is in effect.

o The BAT X 2 command shuts off radio transmissions and causes warning messages to appear on serial port communications.

o The BAT T float command will now set the threshold value at which the green LED blinks to indicate a low internal battery; the same threshold value is used to determine when internal battery charging occurs using a switched external battery (if the external power modification has been implemented).

o If the load switch is used to control a cooling fan, the fan (load switch) will be turned on when the processor temperature reaches 45 °C, and will turn off when the temperature falls below 40 °C (if BAT X 0 has been applied).

o The serial help text now describes the BAT command and the word “Master” has been replaced by “Source”.