### PR TITLE
[codex] Prepare v1.2.2 firmware release

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ Use an Atmel-ICE programmer over the board's UPDI programming header (`P101`) to
 
 For complete programming steps, avrdude examples, and hardware connection details, see the [User Manual](https://docs.google.com/document/d/1eX7xH3cDyRNS-MVg13EojpP8IB8bDgrdszM48J0sn7k/edit?usp=sharing). If you want the current development prerelease instead of the stable public release, switch to the `Development2` branch and use the release files referenced there.
 
+## Firmware Development
+
+Firmware source and build scripts live in [`Software/AVR128DA28`](Software/AVR128DA28).
+
+For the current development workflow, start here:
+
+* [`Software/AVR128DA28/CODEX_WORKFLOW.md`](Software/AVR128DA28/CODEX_WORKFLOW.md) for branch and patch-verification expectations
+* [`Software/AVR128DA28/RELEASE_WORKFLOW.md`](Software/AVR128DA28/RELEASE_WORKFLOW.md) for release preparation and dual-target asset checks
+* [`Software/AVR128DA28/build-firmware.ps1`](Software/AVR128DA28/build-firmware.ps1) for the standard local firmware build
+* [`Software/AVR128DA28/verify-firmware-hashes.ps1`](Software/AVR128DA28/verify-firmware-hashes.ps1) for dual-target `.hex` build and SHA256 verification
+
 ## Related Projects
 
 * [SignalStreamer](https://github.com/OpenARDF/SignalStreamer), a matching antenna

--- a/Software/AVR128DA28/RELEASE_WORKFLOW.md
+++ b/Software/AVR128DA28/RELEASE_WORKFLOW.md
@@ -7,7 +7,7 @@ Unless stated otherwise, commands below assume the current directory is `Softwar
 ## Branch Roles
 
 - `main` is the stable release branch.
-- `Development2` is the development prerelease branch.
+- `Development2` is the active development release branch and may host either prereleases or normal releases when explicitly requested.
 - Before making any software changes, explicitly state the current git branch to the user.
 - On `Development2`, do not automatically commit changes unless the user explicitly authorizes that commit.
 
@@ -23,7 +23,7 @@ git status --short
 3. Confirm the intended firmware version in `SignalSlinger/defs.h` and make sure the repo-root `README.md` references the same asset names for the chosen branch.
 4. Decide the release channel:
    - `main` for a stable release.
-   - `Development2` for a prerelease.
+   - `Development2` for a development-branch release, using either a prerelease or a normal release as explicitly requested.
 5. For routine patch verification before handoff, run:
 
 ```powershell
@@ -56,14 +56,17 @@ $env:HTTPS_PROXY=''
 $env:ALL_PROXY=''
 ```
 
-11. Create the GitHub release:
-   - Use a prerelease on `Development2`.
-   - Use a normal release on `main`.
-12. Upload both hardware assets to the release.
-13. Verify remotely:
+11. Generate GitHub release notes that cover the changes since the previous release.
+12. Create the GitHub release:
+   - Use a prerelease or a normal release on `Development2` according to the requested release channel.
+   - Use a normal release on `main` unless a prerelease is explicitly requested.
+   - Prefer GitHub-generated notes so the release body captures the changes since the prior release automatically.
+13. Upload both hardware assets to the release.
+14. Verify remotely:
    - the release page includes both `.hex` files
+   - the release notes summarize the changes since the previous release
    - `main` README points to stable downloads
-   - `Development2` README points to prerelease downloads
+   - `Development2` README points to the intended development-branch downloads
 
 ## Notes
 

--- a/Software/AVR128DA28/SignalSlinger/defs.h
+++ b/Software/AVR128DA28/SignalSlinger/defs.h
@@ -45,9 +45,9 @@
 
 /******************************************************
  * Set the text that gets displayed to the user */
-#define SW_REVISION "1.2"
-#define HW_TARGET_3_4
-// #define HW_TARGET_3_5
+#define SW_REVISION "1.2.2"
+// #define HW_TARGET_3_4
+#define HW_TARGET_3_5
 
 // #define TRANQUILIZE_WATCHDOG
 
@@ -147,6 +147,12 @@ typedef enum
 #define EXT_BAT_CHARGE_SUPPORT_THRESH_LOW (8.5)
 #define EXT_BAT_PRESENT_VOLTAGE (6.0)
 
+#define EEPROM_THERMAL_SHUTDOWN_THRESHOLD_DEFAULT ((int8_t)50)
+#define EEPROM_PROCESSOR_MAX_EVER_TEMPERATURE_DEFAULT (0.)
+#define THERMAL_SHUTDOWN_THRESHOLD_HYSTERESIS_C ((int8_t)5)
+#define THERMAL_SHUTDOWN_THRESHOLD_MIN_C ((int8_t)-14)
+#define THERMAL_SHUTDOWN_THRESHOLD_MAX_C ((int8_t)119)
+
 // #define FAN_TURN_ON_TEMP (45.)
 // #define FAN_TURN_OFF_TEMP (40.)
 #define FAN_TURN_ON_TEMP (35.)
@@ -167,7 +173,9 @@ typedef uint16_t BatteryLevel; /* in milliVolts */
 
 /******************************************************
  * EEPROM definitions */
-#define EEPROM_INITIALIZED_FLAG (uint16_t)0x0131
+#define EEPROM_INITIALIZED_FLAG_V0131 (uint16_t)0x0131
+#define EEPROM_INITIALIZED_FLAG_V0132 (uint16_t)0x0132
+#define EEPROM_INITIALIZED_FLAG (uint16_t)0x0133
 #define EEPROM_UNINITIALIZED 0x00
 
 #define EEPROM_MASTER_SETTING_DEFAULT false

--- a/Software/AVR128DA28/SignalSlinger/include/adc.h
+++ b/Software/AVR128DA28/SignalSlinger/include/adc.h
@@ -107,6 +107,13 @@ bool isValidTemp(float temperatureC);
 float readVoltage(ADC_Active_Channel_t chan);
 
 /**
+ * Perform a single conversion on the temperature sensor channel and convert it to C.
+ *
+ * @return Measured temperature in degrees Celsius, or an invalid reading when the conversion times out.
+ */
+float readTemperature(void);
+
+/**
  * Initialize the ADC subsystem and its supporting port/reference configuration.
  *
  * @param freerun true to enable free-running conversions; false for single-shot operation.

--- a/Software/AVR128DA28/SignalSlinger/include/eeprommanager.h
+++ b/Software/AVR128DA28/SignalSlinger/include/eeprommanager.h
@@ -115,8 +115,9 @@ struct EE_prom
 	uint32_t reserved_31;
 	uint8_t days_to_run;
 	uint32_t reserved_32;
-	uint16_t reserved_i2c_failure_count;
-	uint32_t reserved_33;
+	int8_t thermal_shutdown_threshold;
+	uint8_t reserved_thermal_shutdown_threshold_padding;
+	float hottest_ever_temperature;
 	uint8_t function;
 	uint32_t reserved_34;
 	uint8_t enable_boost_regulator;
@@ -200,8 +201,8 @@ typedef enum
 	Reserved_31 = EEPROM_OFFSET(reserved_31),
 	Days_to_run = EEPROM_OFFSET(days_to_run),
 	Reserved_32 = EEPROM_OFFSET(reserved_32),
-	Reserved_I2C_Failure_Count = EEPROM_OFFSET(reserved_i2c_failure_count),
-	Reserved_33 = EEPROM_OFFSET(reserved_33),
+	Thermal_Shutdown_Threshold = EEPROM_OFFSET(thermal_shutdown_threshold),
+	Hottest_Ever_Temperature = EEPROM_OFFSET(hottest_ever_temperature),
 	Function = EEPROM_OFFSET(function),
 	Reserved_34 = EEPROM_OFFSET(reserved_34),
 	Enable_Boost_Regulator = EEPROM_OFFSET(enable_boost_regulator),

--- a/Software/AVR128DA28/SignalSlinger/include/globals.h
+++ b/Software/AVR128DA28/SignalSlinger/include/globals.h
@@ -97,10 +97,12 @@ extern volatile bool g_evteng_initialize_event;
 extern volatile float g_internal_voltage_low_threshold; /* FG->ISR + ISR->FG, use shared_state float helpers for snapshots */
 extern volatile float g_internal_bat_voltage;          /* ISR->FG, use shared_state float helpers for snapshots */
 extern volatile bool g_internal_bat_detected;
+extern volatile int8_t g_thermal_shutdown_threshold;   /* FG->ISR + ISR->FG, byte-sized setting is read directly */
 extern volatile float g_external_voltage;              /* ISR->FG, use shared_state float helpers for snapshots */
 extern volatile float g_processor_temperature;         /* ISR->FG, use shared_state float helpers for snapshots */
 extern volatile float g_processor_min_temperature;     /* ISR->FG, use shared_state float helpers for snapshots */
 extern volatile float g_processor_max_temperature;     /* ISR->FG, use shared_state float helpers for snapshots */
+extern volatile float g_processor_max_ever_temperature; /* ISR->FG, use shared_state float helpers for snapshots */
 extern volatile bool g_restart_conversions;
 extern volatile bool g_seconds_transition;
 extern volatile bool g_muteAfterID;

--- a/Software/AVR128DA28/SignalSlinger/include/serialbus.h
+++ b/Software/AVR128DA28/SignalSlinger/include/serialbus.h
@@ -103,6 +103,7 @@ extern "C"
 		SB_MESSAGE_HELP = '?',                                 /* Help */
 		SB_MESSAGE_TEMPERATURE = 'T' * 100 + 'M' * 10 + 'P',   /* Temperature information */
 		SB_MESSAGE_FUNCTION = 'F' * 100 + 'U' * 10 + 'N',      /* Functionality setting */
+		SB_MESSAGE_UI_DIAGNOSTICS = 'U' * 10 + 'I',            /* UI diagnostics and button injection */
 		SB_MODE_MESH = 'M' * 100 + 'S' * 10 + 'H',             /* Meshtastic mode setting */
 		SB_RX_IDLE_TIMEOUT = MAX_UINT16 - 2,                   /* Parser dropped a stale partial RX line */
 		SB_INVALID_MESSAGE = MAX_UINT16,                       /* This value must never overlap a valid message ID */

--- a/Software/AVR128DA28/SignalSlinger/main.cpp
+++ b/Software/AVR128DA28/SignalSlinger/main.cpp
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <time.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 #include <avr/sleep.h>
 #include <atomic.h>
@@ -91,6 +92,11 @@ typedef enum
 	HARDWARE_NO_RTC = 0x01,
 	HARDWARE_NO_SI5351 = 0x02
 } HardwareError_t;
+
+static bool evaluateThermalShutdownState(float processor_temperature, bool internal_bat_detected, bool current_state);
+static uint16_t adcConversionPeriodTicks(uint8_t channel_index);
+static void updateTemperatureState(float temperature);
+static float sampleTemperatureNow(void);
 
 /* Track the current step in the serial cloning/synchronization exchange. */
 typedef enum
@@ -200,10 +206,12 @@ globals. */
 volatile float g_internal_voltage_low_threshold = EEPROM_INT_BATTERY_LOW_THRESHOLD_V;
 volatile float g_internal_bat_voltage = 0.;
 volatile bool g_internal_bat_detected = false;
+volatile int8_t g_thermal_shutdown_threshold = EEPROM_THERMAL_SHUTDOWN_THRESHOLD_DEFAULT;
 volatile float g_external_voltage = 0.;
 volatile float g_processor_temperature = MINIMUM_VALID_TEMP - 1.;
 volatile float g_processor_min_temperature = MAXIMUM_VALID_TEMP + 1.;
 volatile float g_processor_max_temperature = MINIMUM_VALID_TEMP - 1.;
+volatile float g_processor_max_ever_temperature = EEPROM_PROCESSOR_MAX_EVER_TEMPERATURE_DEFAULT;
 volatile bool g_restart_conversions = false;
 volatile bool g_seconds_transition = false;
 volatile bool g_muteAfterID = false; /* Inhibit any transmissions after the ID has been sent */
@@ -249,7 +257,6 @@ static volatile bool g_button_hold_preview_active = false;
 
 #define NUMBER_OF_POLLED_ADC_CHANNELS 3
 static ADC_Active_Channel_t g_adcChannelOrder[NUMBER_OF_POLLED_ADC_CHANNELS] = {ADCInternalBatteryVoltage, ADCExternalBatteryVoltage, ADCTemperature};
-static const uint16_t g_adcChannelConversionPeriod_ticks[NUMBER_OF_POLLED_ADC_CHANNELS] = {TIMER2_0_5HZ, TIMER2_0_5HZ, TIMER2_0_5HZ};
 static volatile uint16_t g_adcCountdownCount[NUMBER_OF_POLLED_ADC_CHANNELS] = {2000, 2000, 4000};
 static volatile uint16_t g_lastConversionResult[NUMBER_OF_POLLED_ADC_CHANNELS] = {0, 0, 0};
 static volatile bool g_thermal_shutdown = false;
@@ -393,6 +400,7 @@ void restoreStateAfterButtonWakeAuthorization(void);
 static bool shouldRestoreTransmitterForSleepContext(SleepType sleepType);
 static inline void clearPendingWakeInterruptFlags(void);
 static inline void setButtonHoldPreviewIndicator(bool active);
+static void refreshProcessorMaxEverTemperature(void);
 bool shouldPowerTransmitterAfterWake(void);
 void configRedLEDforEvent(void);
 bool switchIsClosed(void);
@@ -404,7 +412,6 @@ bool allClocksSet(Settings_t location);
 ConfigurationState_t clockConfigurationCheck(Settings_t location);
 bool startEvent(void);
 static bool foxUsesFastCodeSpeed(Event_t event, Fox_t fox);
-
 
 /*******************************/
 /* Hardcoded event support     */
@@ -433,6 +440,9 @@ static time_t alignEpochToNearestBoundary(time_t epoch, time_t boundary, time_t 
 static bool resolveClockOffsetToEpoch(const char *offsetString, time_t baseEpoch, const char *baseEpochError, bool suppressBaseEpochError, time_t hourBoundary, time_t minuteBoundary, time_t *resolvedEpoch, char *errMsg);
 static void persistClockEpochValue(volatile time_t *loadedEpoch, volatile time_t *savedEpoch, time_t epoch, EE_var_t eeVar, void *eeValue);
 static void acknowledgeClonedClockValue(const char *reply, time_t epoch);
+static void clearCloneUiLatch(void);
+static void reportUiDiagnostics(void);
+static bool injectUiButtonPresses(const char *text);
 static void finalizeLocalClockUpdate(void);
 static Event_t eventFromSerialArg(char eventArg);
 static bool alignSavedClassicStartTimeIfNeeded(char *notice, size_t noticeSize);
@@ -1009,7 +1019,7 @@ ISR(TCB0_INT_vect)
 
 			if(indexConversionInProcess >= 0)
 			{
-				g_adcCountdownCount[indexConversionInProcess] = g_adcChannelConversionPeriod_ticks[indexConversionInProcess]; /* reset the tick countdown */
+				g_adcCountdownCount[indexConversionInProcess] = adcConversionPeriodTicks(indexConversionInProcess); /* reset the tick countdown */
 				ADC0_setADCChannel(g_adcChannelOrder[indexConversionInProcess]);
 				ADC0_startConversion();
 				conversionInProcess = true;
@@ -1049,29 +1059,7 @@ ISR(TCB0_INT_vect)
 				else if(g_adcChannelOrder[indexConversionInProcess] == ADCTemperature)
 				{
 					float temp = temperatureCfromADC(hold);
-
-					if(isValidTemp(temp))
-					{
-						g_processor_temperature = isValidTemp(g_processor_temperature) ? (g_processor_temperature + temp) / 2. : temp;
-						if(g_processor_temperature > g_processor_max_temperature)
-							g_processor_max_temperature = g_processor_temperature;
-						if(g_processor_temperature < g_processor_min_temperature)
-							g_processor_min_temperature = g_processor_temperature;
-
-						if(g_internal_bat_detected)
-						{
-							g_thermal_shutdown = (g_processor_temperature > 60.) ? true : (g_processor_temperature < 50.) ? false
-							                                                                                              : g_thermal_shutdown;
-						}
-						else
-						{
-							g_thermal_shutdown = (g_processor_temperature > 80.) ? true : (g_processor_temperature < 70.) ? false
-							                                                                                              : g_thermal_shutdown;
-						}
-
-						g_turn_on_fan = (g_processor_temperature > FAN_TURN_ON_TEMP) ? true : (g_processor_temperature < FAN_TURN_OFF_TEMP) ? false
-						                                                                                                                    : g_turn_on_fan;
-					}
+					updateTemperatureState(temp);
 				}
 			}
 
@@ -1318,6 +1306,8 @@ int main(void)
 
 	while(1)
 	{
+		refreshProcessorMaxEverTemperature();
+
 		if(g_foreground_enable_serialbus)
 		{
 			g_foreground_enable_serialbus = false;
@@ -3370,6 +3360,62 @@ static void acknowledgeClonedClockValue(const char *reply, time_t epoch)
 }
 
 /**
+ * Clear clone/programming UI latches without rebooting or changing settings.
+ */
+static void clearCloneUiLatch(void)
+{
+	atomic_write_u16(&g_send_clone_success_countdown, 0);
+	atomic_write_u16(&g_programming_countdown, 0);
+	atomic_write_u16(&g_programming_msg_throttle, 0);
+	g_cloningInProgress = false;
+	g_defer_cloned_event_start = false;
+}
+
+/**
+ * Report compact UI and clone state for automated tests.
+ */
+static void reportUiDiagnostics(void)
+{
+	sprintf(g_tempStr, "* UI cs=%u cl=%u df=%u pc=%u pt=%u\n",
+	        atomic_read_u16(&g_send_clone_success_countdown),
+	        g_cloningInProgress ? 1 : 0,
+	        g_defer_cloned_event_start ? 1 : 0,
+	        atomic_read_u16(&g_programming_countdown),
+	        atomic_read_u16(&g_programming_msg_throttle));
+	sb_send_master_string(g_tempStr);
+
+	sprintf(g_tempStr, "* UI ms=%u mc=%u ee=%u ec=%u ru=%u fs=%u\n",
+	        g_isMaster ? 1 : 0,
+	        atomic_read_u16(&isMasterCountdownSeconds),
+	        g_evteng_event_enabled ? 1 : 0,
+	        g_evteng_event_commenced ? 1 : 0,
+	        g_evteng_run_event_until_canceled ? 1 : 0,
+	        g_foreground_start_event ? 1 : 0);
+	sb_send_master_string(g_tempStr);
+}
+
+/**
+ * Queue counted button presses for the normal foreground button dispatcher.
+ */
+static bool injectUiButtonPresses(const char *text)
+{
+	if(!text || !text[0])
+	{
+		return false;
+	}
+
+	char *end = NULL;
+	long presses = strtol(text, &end, 10);
+	if((end == text) || (end && *end) || (presses < 1) || (presses > 9))
+	{
+		return false;
+	}
+
+	atomic_write_u16(&g_foreground_handle_counted_presses, (uint16_t)presses);
+	return true;
+}
+
+/**
  * Reset day tracking and restart event scheduling after a local clock update.
  */
 static void finalizeLocalClockUpdate(void)
@@ -3730,6 +3776,183 @@ static inline void setButtonHoldPreviewIndicator(bool active)
 }
 
 /**
+ * Persist a new hottest-ever processor temperature when the current session's
+ * maximum exceeds the stored all-time maximum.
+ */
+static void refreshProcessorMaxEverTemperature(void)
+{
+	float processor_max_temperature = atomic_read_float(&g_processor_max_temperature);
+	float processor_max_ever_temperature = atomic_read_float(&g_processor_max_ever_temperature);
+
+	if(isValidTemp(processor_max_temperature) && (processor_max_temperature > processor_max_ever_temperature))
+	{
+		atomic_write_float(&g_processor_max_ever_temperature, processor_max_temperature);
+		g_ee_mgr.updateEEPROMVar(Hottest_Ever_Temperature, (void *)&processor_max_temperature);
+	}
+}
+
+/**
+ * Apply the configured thermal-shutdown hysteresis for the current battery mode.
+ *
+ * The EEPROM-backed threshold is the internal-battery trip temperature and the
+ * no-internal-battery clear temperature. Internal-battery clear uses a 5 C
+ * hysteresis band below that threshold, while no-internal-battery trip uses a
+ * 5 C band above it.
+ *
+ * @param processor_temperature Current measured processor temperature in C.
+ * @param internal_bat_detected true when an internal battery is present.
+ * @param current_state Existing latched thermal shutdown state.
+ * @return Updated latched thermal shutdown state.
+ */
+static bool evaluateThermalShutdownState(float processor_temperature, bool internal_bat_detected, bool current_state)
+{
+	int8_t threshold = g_thermal_shutdown_threshold;
+	int8_t clear_threshold_with_internal_battery = threshold - THERMAL_SHUTDOWN_THRESHOLD_HYSTERESIS_C;
+	int8_t trip_threshold_without_internal_battery = threshold + THERMAL_SHUTDOWN_THRESHOLD_HYSTERESIS_C;
+
+	if(internal_bat_detected)
+	{
+		return (processor_temperature >= threshold)                               ? true
+		       : (processor_temperature <= clear_threshold_with_internal_battery) ? false
+		                                                                          : current_state;
+	}
+
+	return (processor_temperature >= trip_threshold_without_internal_battery) ? true
+	       : (processor_temperature <= threshold)                             ? false
+	                                                                          : current_state;
+}
+
+/**
+ * Choose the polling interval for a periodic ADC channel.
+ *
+ * Temperature is sampled more aggressively as it approaches the configured
+ * shutdown threshold so the thermal shutdown path has less chance to overshoot
+ * between readings.
+ */
+static uint16_t adcConversionPeriodTicks(uint8_t channel_index)
+{
+	if(g_adcChannelOrder[channel_index] != ADCTemperature)
+	{
+		return TIMER2_0_5HZ;
+	}
+
+	float processor_temperature = g_processor_temperature;
+	if(isValidTemp(processor_temperature) &&
+	   (processor_temperature >= ((float)g_thermal_shutdown_threshold - (float)THERMAL_SHUTDOWN_THRESHOLD_HYSTERESIS_C)))
+	{
+		return TIMER2_5_8HZ;
+	}
+
+	return TIMER2_0_5HZ;
+}
+
+/**
+ * Apply a temperature reading to runtime state and thermal-protection outputs.
+ */
+static void updateTemperatureState(float temperature)
+{
+	if(!isValidTemp(temperature))
+	{
+		return;
+	}
+
+	g_processor_temperature = isValidTemp(g_processor_temperature) ? (g_processor_temperature + temperature) / 2. : temperature;
+	if(g_processor_temperature > g_processor_max_temperature)
+		g_processor_max_temperature = g_processor_temperature;
+	if(g_processor_temperature < g_processor_min_temperature)
+		g_processor_min_temperature = g_processor_temperature;
+
+	g_thermal_shutdown = evaluateThermalShutdownState(g_processor_temperature, g_internal_bat_detected, g_thermal_shutdown);
+
+	g_turn_on_fan = (g_processor_temperature > FAN_TURN_ON_TEMP) ? true : (g_processor_temperature < FAN_TURN_OFF_TEMP) ? false
+	                                                                                                                    : g_turn_on_fan;
+}
+
+/**
+ * Take and store a fresh temperature sample for foreground requests.
+ *
+ * @return The updated processor temperature after filtering, or the prior value
+ * when the immediate ADC read is invalid.
+ */
+static float sampleTemperatureNow(void)
+{
+	float immediate_temperature = readTemperature();
+	updateTemperatureState(immediate_temperature);
+	float processor_temperature = atomic_read_float(&g_processor_temperature);
+	float processor_max_ever_temperature = atomic_read_float(&g_processor_max_ever_temperature);
+	if(isValidTemp(processor_temperature) && (!isValidTemp(processor_max_ever_temperature) || processor_temperature > processor_max_ever_temperature))
+	{
+		atomic_write_float(&g_processor_max_ever_temperature, processor_temperature);
+		g_ee_mgr.updateEEPROMVar(Hottest_Ever_Temperature, (void *)&processor_temperature);
+	}
+	return processor_temperature;
+}
+
+/**
+ * Parse a user-supplied thermal shutdown threshold from serial command text.
+ *
+ * @param text Null-terminated decimal string to parse.
+ * @param threshold_out Receives the validated threshold on success.
+ * @return true when parsing succeeded and the value is in range.
+ */
+static bool tryParseThermalShutdownThreshold(const char *text, int8_t *threshold_out)
+{
+	if(!text || !threshold_out || !text[0])
+	{
+		return false;
+	}
+
+	char *end = NULL;
+	long parsed = strtol(text, &end, 10);
+	if((end == text) || (end && *end))
+	{
+		return false;
+	}
+
+	if((parsed < THERMAL_SHUTDOWN_THRESHOLD_MIN_C) || (parsed > THERMAL_SHUTDOWN_THRESHOLD_MAX_C))
+	{
+		return false;
+	}
+
+	*threshold_out = (int8_t)parsed;
+	return true;
+}
+
+/**
+ * Send one labeled temperature line over the serial interface.
+ *
+ * @param label Label prefix to print before the temperature value.
+ * @param temperature Temperature in C to report.
+ */
+static void sendTemperatureReportLine(const char *label, float temperature)
+{
+	if(isValidTemp(temperature))
+	{
+		int16_t integer;
+		uint16_t fractional;
+
+		if(!float_to_parts_signed(temperature, &integer, &fractional))
+		{
+			sprintf(g_tempStr, "* %s: %d.%uC\n", label, integer, fractional);
+			sb_send_string(g_tempStr);
+			return;
+		}
+	}
+
+	sprintf(g_tempStr, "* %s: not available\n", label);
+	sb_send_string(g_tempStr);
+}
+
+/**
+ * Report the configured EEPROM-backed thermal shutdown threshold.
+ */
+static void sendThermalShutdownThresholdLine(void)
+{
+	sprintf(g_tempStr, "* Thermal shutdown threshold: %dC\n", g_thermal_shutdown_threshold);
+	sb_send_string(g_tempStr);
+}
+
+/**
  * Consume and handle all pending serialbus commands.
  *
  * This foreground dispatcher parses each queued command message, updates
@@ -3779,27 +4002,89 @@ void __attribute__((optimize("O0"))) handleSerialBusMsgs()
 			}
 			break;
 
-			case SB_MESSAGE_TEMPERATURE:
+			case SB_MESSAGE_UI_DIAGNOSTICS:
 			{
-				float processor_temperature = atomic_read_float(&g_processor_temperature);
-				if(isValidTemp(processor_temperature))
+				char command = sb_buff->fields[SB_FIELD1][0];
+				if(command == 'S')
 				{
-					int16_t integer;
-					uint16_t fractional;
-
-					if(!float_to_parts_signed(processor_temperature, &integer, &fractional))
+					reportUiDiagnostics();
+				}
+				else if(command == 'C')
+				{
+					clearCloneUiLatch();
+					sb_send_master_string((char *)"* UI C\n");
+				}
+				else if(command == 'P')
+				{
+					if(injectUiButtonPresses(sb_buff->fields[SB_FIELD2]))
 					{
-						if(!g_meshmode)
-							sb_send_NewLine();
-						sprintf(g_tempStr, "* Temp: %d.%dC\n", integer, fractional);
-						sb_send_string(g_tempStr);
+						sb_send_master_string((char *)"* UI P\n");
+					}
+					else
+					{
+						sb_send_master_string((char *)"* Err: UI [S|C|P n]\n");
 					}
 				}
 				else
 				{
+					sb_send_master_string((char *)"* Err: UI [S|C|P n]\n");
+				}
+			}
+			break;
+
+			case SB_MESSAGE_TEMPERATURE:
+			{
+				if(sb_buff->fields[SB_FIELD1][0] == 'H')
+				{
+					if(sb_buff->fields[SB_FIELD2][0] != '\0')
+					{
+						int8_t new_threshold = 0;
+						if(tryParseThermalShutdownThreshold(sb_buff->fields[SB_FIELD2], &new_threshold))
+						{
+							g_thermal_shutdown_threshold = new_threshold;
+							g_ee_mgr.updateEEPROMVar(Thermal_Shutdown_Threshold, (void *)&g_thermal_shutdown_threshold);
+
+							float processor_temperature = atomic_read_float(&g_processor_temperature);
+							g_thermal_shutdown =
+							    evaluateThermalShutdownState(processor_temperature, g_internal_bat_detected, g_thermal_shutdown);
+						}
+						else
+						{
+							if(!g_meshmode)
+								sb_send_NewLine();
+							sprintf(g_tempStr, "* Err: %dC <= TMP H <= %dC\n",
+							        THERMAL_SHUTDOWN_THRESHOLD_MIN_C,
+							        THERMAL_SHUTDOWN_THRESHOLD_MAX_C);
+							sb_send_string(g_tempStr);
+							break;
+						}
+					}
+
 					if(!g_meshmode)
 						sb_send_NewLine();
-					sb_send_string((char *)"* Temp not available\n");
+					sendThermalShutdownThresholdLine();
+				}
+				else if(sb_buff->fields[SB_FIELD1][0] != '\0')
+				{
+					if(!g_meshmode)
+						sb_send_NewLine();
+					sb_send_string((char *)"* Err: TMP [H [n]]\n");
+				}
+				else
+				{
+					sampleTemperatureNow();
+					float processor_max_ever_temperature = atomic_read_float(&g_processor_max_ever_temperature);
+					float processor_max_temperature = atomic_read_float(&g_processor_max_temperature);
+					float processor_temperature = atomic_read_float(&g_processor_temperature);
+					float processor_min_temperature = atomic_read_float(&g_processor_min_temperature);
+
+					if(!g_meshmode)
+						sb_send_NewLine();
+					sendTemperatureReportLine("Max Ever", processor_max_ever_temperature);
+					sendTemperatureReportLine("Max Temp", processor_max_temperature);
+					sendTemperatureReportLine("Temp", processor_temperature);
+					sendTemperatureReportLine("Min Temp", processor_min_temperature);
+					sendThermalShutdownThresholdLine();
 				}
 			}
 			break;
@@ -6760,11 +7045,11 @@ void reportConfigErrors(Settings_t location)
 		}
 		else if(eventIsScheduledToRun(&start_epoch, &finish_epoch) && (!g_evteng_event_enabled && !g_foreground_start_event))
 		{
-			sb_send_string((char *)"Start with > GO 1 or > GO 2\n");
+			sb_send_string((char *)"* Start with > GO 1 or > GO 2\n");
 		}
 		else
 		{
-			sb_send_string((char *)"None: Event running.\n");
+			sb_send_string((char *)"* None: Event running.\n");
 		}
 	}
 	else if(start_epoch == finish_epoch)
@@ -7116,7 +7401,7 @@ int getFoxCodeSpeed(void)
 	Fox_t fox;
 	Event_t event_snapshot;
 	event_and_fox_current_atomic(&event_snapshot, &fox);
-	
+
 	if(event_snapshot == EVENT_FOXORING)
 	{
 		return (g_foxoring_pattern_codespeed);
@@ -7202,7 +7487,7 @@ static bool foxUsesFastCodeSpeed(Event_t event, Fox_t fox)
 		return false;
 	}
 
-    if((fox_index >= SPRINT_F1) && (fox_index <= SPRINT_F5))
+	if((fox_index >= SPRINT_F1) && (fox_index <= SPRINT_F5))
 	{
 		return true;
 	}

--- a/Software/AVR128DA28/SignalSlinger/src/adc.cpp
+++ b/Software/AVR128DA28/SignalSlinger/src/adc.cpp
@@ -227,15 +227,10 @@ float temperatureCfromADC(uint16_t adc_reading)
 {
 	uint16_t sigrow_offset = SIGROW.TEMPSENSE1; // Read unsigned value from signature row
 	uint16_t sigrow_slope = SIGROW.TEMPSENSE0;  // Read unsigned value from signature row
-	float temperature_in_C = -273.15;
+	int32_t sensor_delta = (int32_t)sigrow_offset - (int32_t)adc_reading;
+	float temperature_in_K = ((float)sensor_delta * (float)sigrow_slope) / 4096.0f;
 
-	uint32_t temp = sigrow_offset - adc_reading;
-	temp *= sigrow_slope; // Result will overflow 16-bit variable
-	temp += 0x0800;       // Add 4096/2 to get correct rounding on division below
-	temp >>= 12;          // Round off to nearest degree in Kelvin, by dividing with 2^12 (4096)
-	temperature_in_C += (float)temp;
-
-	return (temperature_in_C);
+	return (temperature_in_K - 273.15f);
 }
 
 /**

--- a/Software/AVR128DA28/SignalSlinger/src/adc.cpp
+++ b/Software/AVR128DA28/SignalSlinger/src/adc.cpp
@@ -181,6 +181,32 @@ float readVoltage(ADC_Active_Channel_t chan)
 }
 
 /**
+ * Perform a single conversion on the temperature sensor channel and convert it to C.
+ *
+ * @return Measured temperature in degrees Celsius, or an invalid reading when the conversion times out.
+ */
+float readTemperature(void)
+{
+	uint16_t adc_reading = ADC0.RES;
+	uint32_t wait = 10000;
+	float temperature = MINIMUM_VALID_TEMP - 1.;
+
+	ADC0_setADCChannel(ADCTemperature);
+	ADC0_startConversion();
+
+	while((!ADC0_conversionDone()) && wait--)
+		;
+
+	if(wait)
+	{
+		adc_reading = ADC0.RES;
+		temperature = temperatureCfromADC(adc_reading);
+	}
+
+	return (temperature);
+}
+
+/**
  * Check whether a temperature reading falls inside the firmware's valid range.
  *
  * @param temperatureC Temperature in degrees Celsius.

--- a/Software/AVR128DA28/SignalSlinger/src/eeprommanager.cpp
+++ b/Software/AVR128DA28/SignalSlinger/src/eeprommanager.cpp
@@ -110,8 +110,9 @@ const struct EE_prom EEMEM EepromManager::ee_vars =
         0x00000000,                                   //  reserved
         0x00,                                         //  uint8_t days_to_run
         0x00000000,                                   //  reserved
-        0x0000,                                       // uint16_t reserved_i2c_failure_count;
-        0x00000000,                                   //  reserved
+        0x00,                                         // int8_t thermal_shutdown_threshold;
+        0x00,                                         // uint8_t reserved_thermal_shutdown_threshold_padding;
+        0x00000000,                                   //  float hottest_ever_temperature
         0x00,                                         //  uint8_t function
         0x00000000,                                   //  reserved
         0x00,                                         //  uint8_t enable_boost_regulator
@@ -411,6 +412,39 @@ static Fox_t avr_eeprom_read_clamped_fox(eeprom_addr_t index, Fox_t max_value)
 }
 
 /**
+ * Upgrade known older EEPROM layouts in place to the current version.
+ *
+ * Version 0x0131 predates both new thermal fields, so migration seeds the
+ * thermal shutdown threshold and hottest-ever temperature with defaults.
+ * Version 0x0132 already contains the threshold field, so it only needs the
+ * hottest-ever value initialized. In both cases the version marker is written
+ * last so a partial migration can be retried safely on the next boot.
+ *
+ * @param initialization_flag Stored EEPROM layout version.
+ * @return true when a known prior layout was migrated, false otherwise.
+ */
+static bool migrateEEPROMLayoutIfNeeded(uint16_t initialization_flag)
+{
+	if(initialization_flag == EEPROM_INITIALIZED_FLAG_V0131)
+	{
+		avr_eeprom_write_byte(Thermal_Shutdown_Threshold, (uint8_t)EEPROM_THERMAL_SHUTDOWN_THRESHOLD_DEFAULT);
+		avr_eeprom_write_byte(Thermal_Shutdown_Threshold + 1, 0);
+		avr_eeprom_write_float(Hottest_Ever_Temperature, EEPROM_PROCESSOR_MAX_EVER_TEMPERATURE_DEFAULT);
+		avr_eeprom_write_word(Eeprom_initialization_flag, EEPROM_INITIALIZED_FLAG);
+		return true;
+	}
+
+	if(initialization_flag == EEPROM_INITIALIZED_FLAG_V0132)
+	{
+		avr_eeprom_write_float(Hottest_Ever_Temperature, EEPROM_PROCESSOR_MAX_EVER_TEMPERATURE_DEFAULT);
+		avr_eeprom_write_word(Eeprom_initialization_flag, EEPROM_INITIALIZED_FLAG);
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * Persist one named runtime value to EEPROM.
  *
  * The enum value identifies both the EEPROM offset and the storage width, so
@@ -446,6 +480,7 @@ void EepromManager::updateEEPROMVar(EE_var_t v, void *val)
 		case Event_setting:
 		case Utc_offset:
 		case Days_to_run:
+		case Thermal_Shutdown_Threshold:
 		case Function:
 		case Enable_Boost_Regulator:
 		case Enable_External_Battery_Control:
@@ -474,6 +509,7 @@ void EepromManager::updateEEPROMVar(EE_var_t v, void *val)
 			break;
 
 		case Voltage_threshold:
+		case Hottest_Ever_Temperature:
 			avr_eeprom_write_float_if_changed((eeprom_addr_t)v, *(const float *)val);
 			break;
 
@@ -518,6 +554,8 @@ void EepromManager::saveAllEEPROM(void)
 	updateEEPROMVar(Voltage_threshold, (void *)&g_internal_voltage_low_threshold);
 	updateEEPROMVar(Clock_calibration, (void *)&g_clock_calibration);
 	updateEEPROMVar(Days_to_run, (void *)&g_days_to_run);
+	updateEEPROMVar(Thermal_Shutdown_Threshold, (void *)&g_thermal_shutdown_threshold);
+	updateEEPROMVar(Hottest_Ever_Temperature, (void *)&g_processor_max_ever_temperature);
 	updateEEPROMVar(Function, (void *)&g_function);
 	updateEEPROMVar(Enable_Boost_Regulator, (void *)&g_enable_boost_regulator);
 	updateEEPROMVar(Enable_External_Battery_Control, (void *)&g_enable_external_battery_control);
@@ -587,6 +625,17 @@ bool EepromManager::readNonVols(void)
 
 		g_days_to_run = avr_eeprom_read_byte_at(Days_to_run);
 
+		g_thermal_shutdown_threshold =
+		    CLAMP(THERMAL_SHUTDOWN_THRESHOLD_MIN_C,
+		          (int8_t)avr_eeprom_read_byte_at(Thermal_Shutdown_Threshold),
+		          THERMAL_SHUTDOWN_THRESHOLD_MAX_C);
+
+		float hottest_ever_temperature = avr_eeprom_read_float_at(Hottest_Ever_Temperature);
+		g_processor_max_ever_temperature =
+		    (isValidTemp(hottest_ever_temperature) && (hottest_ever_temperature >= EEPROM_PROCESSOR_MAX_EVER_TEMPERATURE_DEFAULT))
+		        ? hottest_ever_temperature
+		        : EEPROM_PROCESSOR_MAX_EVER_TEMPERATURE_DEFAULT;
+
 		g_function = (Function_t)avr_eeprom_read_byte_at(Function);
 
 		g_enable_external_battery_control = (bool)avr_eeprom_read_byte_at(Enable_External_Battery_Control);
@@ -613,7 +662,16 @@ bool EepromManager::initializeEEPROMVars(void)
 	bool init = false;
 	uint16_t initialization_flag = avr_eeprom_read_word_at(Eeprom_initialization_flag);
 
-	if(initialization_flag != EEPROM_INITIALIZED_FLAG)
+	if(initialization_flag == EEPROM_INITIALIZED_FLAG)
+	{
+		return init;
+	}
+
+	if(migrateEEPROMLayoutIfNeeded(initialization_flag))
+	{
+		return init;
+	}
+
 	{
 		/* First-time initialization writes defaults to both RAM globals and EEPROM. */
 		g_evteng_id_codespeed = EEPROM_ID_CODE_SPEED_DEFAULT;
@@ -706,7 +764,11 @@ bool EepromManager::initializeEEPROMVars(void)
 		g_days_to_run = 1;
 		avr_eeprom_write_byte(Days_to_run, g_days_to_run);
 
-		avr_eeprom_write_word(Reserved_I2C_Failure_Count, 0);
+		g_thermal_shutdown_threshold = EEPROM_THERMAL_SHUTDOWN_THRESHOLD_DEFAULT;
+		avr_eeprom_write_byte(Thermal_Shutdown_Threshold, (uint8_t)g_thermal_shutdown_threshold);
+
+		g_processor_max_ever_temperature = EEPROM_PROCESSOR_MAX_EVER_TEMPERATURE_DEFAULT;
+		avr_eeprom_write_float(Hottest_Ever_Temperature, g_processor_max_ever_temperature);
 
 		g_function = EEPROM_FUNCTION_DEFAULT;
 		avr_eeprom_write_byte(Function, (uint8_t)g_function);

--- a/prepare-release.ps1
+++ b/prepare-release.ps1
@@ -84,13 +84,13 @@ function Set-HardwareTargetContent {
     {
         '3.4' {
             $updated = $DefsText `
-                -replace '(?m)^// #define HW_TARGET_3_4$','#define HW_TARGET_3_4' `
-                -replace '(?m)^#define HW_TARGET_3_5$','// #define HW_TARGET_3_5'
+                -replace '(?m)^\s*(?://\s*)?#define HW_TARGET_3_4\s*$','#define HW_TARGET_3_4' `
+                -replace '(?m)^\s*(?://\s*)?#define HW_TARGET_3_5\s*$','// #define HW_TARGET_3_5'
         }
         '3.5' {
             $updated = $DefsText `
-                -replace '(?m)^#define HW_TARGET_3_4$','// #define HW_TARGET_3_4' `
-                -replace '(?m)^// #define HW_TARGET_3_5$','#define HW_TARGET_3_5'
+                -replace '(?m)^\s*(?://\s*)?#define HW_TARGET_3_4\s*$','// #define HW_TARGET_3_4' `
+                -replace '(?m)^\s*(?://\s*)?#define HW_TARGET_3_5\s*$','#define HW_TARGET_3_5'
         }
     }
 


### PR DESCRIPTION
## Summary

Prepare the AVR128DA28 firmware tree and release workflow for the v1.2.2 normal release.

This PR intentionally keeps CAD work out of scope: no `KiCad/` or `FreeCAD/` files are included. It also keeps the SerialSlinger-only `UI` diagnostics command hidden from user-facing firmware help while preserving the command handler for SerialSlinger automation.

## Changes

- Bumps firmware-reported version to `1.2.2` and keeps the active default hardware target formatting clean.
- Adds thermal sampling/thermal shutdown threshold support, EEPROM migration for the new thermal fields, and hottest-ever temperature persistence/reporting.
- Preserves fractional temperature conversion instead of rounding ADC temperature readings to whole Kelvin before reporting/filtering.
- Keeps clone/UI diagnostic plumbing available for SerialSlinger while removing it from the public help text.
- Updates release workflow guidance for a normal v1.2.2 release and improves release target switching robustness.
- Adds a durable README firmware-development section without changing public release asset links yet; those should update during final release prep when v1.2.2 assets are generated.

## Validation

- `git diff --check`
- Confirmed PR diff has no `KiCad/` or `FreeCAD/` paths.
- `Software/AVR128DA28/build-firmware.ps1 -Configuration Release`
- Release build size: `text=84680`, `data=5172`, `bss=904`.